### PR TITLE
fix: Correct parsing of numbers with leading dot

### DIFF
--- a/lib/lang/python.spec.ts
+++ b/lib/lang/python.spec.ts
@@ -2,7 +2,15 @@ import { loadInputTxt, loadOutputJson } from '../../test/test-utils';
 import { lang as pythonLang } from './python';
 import { createLang } from '.';
 
+const lang = createLang(pythonLang);
+
 describe('lang/python', () => {
+  it('does not confuse operator and number literal', () => {
+    const value = '.42';
+    const res = lang.parse(value).down?.node;
+    expect(res).toMatchObject({ type: 'number', value });
+  });
+
   test.each`
     name
     ${'setup.py'}
@@ -24,8 +32,9 @@ describe('lang/python', () => {
     ${'setup.py'}
   `('$name', ({ name }) => {
     const input = loadInputTxt(name);
-    const lang = createLang(pythonLang);
+
     const res = lang.parse(input).node;
+
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const expected = loadOutputJson(name, res);
     expect(res).toEqual(expected);
@@ -33,7 +42,6 @@ describe('lang/python', () => {
 
   it('supports line joins', () => {
     const input = loadInputTxt('line-join');
-    const lang = createLang(pythonLang);
 
     const res = lang.parse(input)?.node;
 

--- a/lib/lexer/index.ts
+++ b/lib/lexer/index.ts
@@ -28,10 +28,10 @@ export function configureLexerRules(lexerConfig: LexerConfig): StatesMap {
     lexerConfig;
   result = configComments(result, comments);
   result = configSymbols(result, { match: symbols });
-  result = configNumbers(result, { match: numbers });
   result = configOperators(result, operators);
   result = configBrackets(result, brackets);
   result = configStrings(result, strings);
+  result = configNumbers(result, { match: numbers });
   return result;
 }
 

--- a/lib/lexer/number.ts
+++ b/lib/lexer/number.ts
@@ -1,4 +1,3 @@
-import { sortStateRules } from './rules';
 import type { NumberOption, StatesMap } from './types';
 
 export function configNumbers(
@@ -7,9 +6,9 @@ export function configNumbers(
 ): StatesMap {
   return {
     ...states,
-    $: sortStateRules({
-      ...states.$,
+    $: {
       number: { t: 'regex', match },
-    }),
+      ...states.$,
+    },
   };
 }


### PR DESCRIPTION
It will be important for scenarios when version is defined as floating number, but language still understands it thanks to type conversion.