### PR TITLE
docs: add readme boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # Renovate parser utils
+
+One line summary of the program goes here.
+
+## License
+
+[license](https://github.com/renovatebot/parser-utils/blob/main/LICENSE).
+
+## Background
+
+We created the `parser-utils` library because .....
+Explain why we decided to make this library, what were we missing with any existing packages?
+
+Explain that the package is meant for Renovate's internal use, but others might benefit as well.
+
+## Installation
+
+Explain here how to install the package/library.
+
+## Configuration
+
+Explain here how to configure the package/libary.
+
+## Usage
+
+Explain here how to use the package/library.
+
+## Contributing
+
+Add link to CONTRIBUTING.md file that will explain how to get started developing for this package.
+This can be done once things stabilize enough for us to accept external contributions.


### PR DESCRIPTION
## Changes:

- Add readme boilerplate text that @zharinov can fill in

## Context:

As requested by @zharinov. 😉 

The idea here is that we have some categories, that can be filled in, to make it clear to anybody who stumbles upon this repository what this package is all about, how to use it, and so on.