### PR TITLE
chore: remove link to upstream repo discussion

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,1 @@
 blank_issues_enabled: false
-contact_links:
-  - name: ✋ Question
-    about: You have a question about something you're not sure about
-    url: https://github.com/jasonkuhrt/template-typescript-lib/discussions/new


### PR DESCRIPTION
- Remove link to upstream repo discussion

It makes no sense to have a link to the original template repository.
If we later on decide to use discussions on this repository, we can add a link to our own discussions forum. 😉 
