### PR TITLE
refactor: Separate classes for string matching

### DIFF
--- a/lib/query/builder.spec.ts
+++ b/lib/query/builder.spec.ts
@@ -200,20 +200,34 @@ describe('query/builder', () => {
   });
 
   describe('String builder', () => {
-    const foo = builder.sym('foo');
+    it('handles empty argument list', () => {
+      const matcher = builder.str().build();
+      expect(matcher).toEqual({
+        matchers: null,
+        preHandler: null,
+        postHandler: null,
+      });
+    });
+
+    it('handles exact string parameter', () => {
+      const matcher = builder.str('foobar').build();
+      expect(matcher).toEqual({
+        matchers: [{ content: 'foobar', handler: null }],
+        preHandler: null,
+        postHandler: null,
+      });
+    });
 
     test.each`
-      arg1                       | arg2         | preHandler | postHandler | matchers
-      ${undefined}               | ${undefined} | ${null}    | ${null}     | ${null}
-      ${'foobar'}                | ${undefined} | ${null}    | ${null}     | ${['foobar']}
-      ${'foobar'}                | ${handler}   | ${null}    | ${null}     | ${['foobar']}
-      ${/foobar/}                | ${undefined} | ${null}    | ${null}     | ${[/foobar/]}
-      ${/foobar/}                | ${handler}   | ${null}    | ${null}     | ${[/foobar/]}
-      ${{ match: [foo, 'bar'] }} | ${undefined} | ${null}    | ${null}     | ${[expect.any(SymMatcher), 'bar']}
+      arg1         | arg2         | preHandler | postHandler | matchers
+      ${undefined} | ${undefined} | ${null}    | ${null}     | ${null}
+      ${'foobar'}  | ${undefined} | ${null}    | ${null}     | ${[{ content: 'foobar' }]}
+      ${'foobar'}  | ${handler}   | ${null}    | ${null}     | ${[{ content: 'foobar' }]}
+      ${/foobar/}  | ${undefined} | ${null}    | ${null}     | ${[{ content: /foobar/ }]}
+      ${/foobar/}  | ${handler}   | ${null}    | ${null}     | ${[{ content: /foobar/ }]}
     `('str($arg1, $arg2)', ({ arg1, preHandler, postHandler, matchers }) => {
       const treeSeq = arg1 ? builder.str(arg1).str(arg1) : builder.str().str();
       const expected = {
-        type: 'string-tree',
         preHandler,
         postHandler,
         matchers,

--- a/lib/query/matchers/str-matcher.ts
+++ b/lib/query/matchers/str-matcher.ts
@@ -1,17 +1,146 @@
-import type {
-  StrMatcherOptions,
-  StrMatcherValue,
-  TreeNodeMatcherHandler,
-} from '../types';
-import { TreeNodeMatcher } from './tree-macher';
+import { StringValueToken } from '../../lexer/types';
+import { StringTree, TemplateTree } from '../../parser/types';
+import type { Checkpoint, TreeNodeMatcherHandler } from '../types';
+import { AbstractMatcher } from './abstract-matcher';
+import { TreeNodeWalkingMatcher } from './tree-macher';
+import { skipMinorTokens } from './util';
 
-export class StrMatcher<Ctx> extends TreeNodeMatcher<Ctx> {
-  public matchers: StrMatcherValue<Ctx>[] | null;
-  public readonly postHandler: TreeNodeMatcherHandler<Ctx> | null;
+export type StrContentMatcherValue = string | RegExp | null;
+export type StrContentMatcherHandler<Ctx> = (
+  ctx: Ctx,
+  token: StringValueToken
+) => Ctx;
+export interface StrContentMatcherOptions<Ctx> {
+  value: StrContentMatcherValue;
+  handler: StrContentMatcherHandler<Ctx> | null;
+}
+
+export type StrNodeChildMatcher<Ctx> =
+  | StrContentMatcher<Ctx>
+  | StrTplMatcher<Ctx>;
+
+export interface StrMatcherOptions<Ctx> {
+  matchers: StrNodeChildMatcher<Ctx>[] | null;
+  preHandler: TreeNodeMatcherHandler<Ctx> | null;
+  postHandler: TreeNodeMatcherHandler<Ctx> | null;
+}
+
+export class StrContentMatcher<Ctx> extends AbstractMatcher<Ctx> {
+  public readonly content: StrContentMatcherValue;
+  public readonly handler: StrContentMatcherHandler<Ctx> | null;
+
+  constructor({ value, handler }: StrContentMatcherOptions<Ctx>) {
+    super();
+    this.content = value ?? null;
+    this.handler = handler ?? null;
+  }
+
+  override match(checkpoint: Checkpoint<Ctx>): Checkpoint<Ctx> | null {
+    const { cursor, context } = checkpoint;
+    const node = cursor.node;
+    if (node.type === 'string-value') {
+      let isMatched = true;
+      if (typeof this.content === 'string') {
+        isMatched = this.content === node.value;
+      } else if (this.content instanceof RegExp) {
+        isMatched = this.content.test(node.value);
+      }
+
+      if (isMatched) {
+        const nextContext = this.handler
+          ? this.handler(context, node)
+          : context;
+        const nextCursor = cursor.right;
+        return nextCursor
+          ? { context: nextContext, cursor: nextCursor }
+          : { context: nextContext, cursor, endOfLevel: true };
+      }
+    }
+
+    return null;
+  }
+}
+
+export class StrTplMatcher<Ctx> extends TreeNodeWalkingMatcher<
+  Ctx,
+  TemplateTree
+> {
+  override match(checkpoint: Checkpoint<Ctx>): Checkpoint<Ctx> | null {
+    const { cursor: rootCursor, context: rootContext } = checkpoint;
+    const rootNode = rootCursor.node;
+    if (rootNode.type === 'template-tree') {
+      const cursor = checkpoint.cursor.down;
+      if (cursor && cursor.node) {
+        const childMatch = this.seekNextChild({
+          context: this.preHandler
+            ? this.preHandler(rootContext, rootNode)
+            : rootContext,
+          cursor,
+        });
+
+        if (childMatch && !skipMinorTokens(childMatch)) {
+          const cursor = rootCursor.right;
+          const context = this.postHandler
+            ? this.postHandler(childMatch.context, rootNode)
+            : childMatch.context;
+          return cursor
+            ? { context, cursor }
+            : { context, cursor: rootCursor, endOfLevel: true };
+        }
+      }
+    }
+
+    return null;
+  }
+}
+
+export class StrNodeMatcher<Ctx> extends AbstractMatcher<Ctx> {
+  public matchers: StrNodeChildMatcher<Ctx>[] | null;
+  public readonly preHandler: TreeNodeMatcherHandler<Ctx, StringTree> | null;
+  public readonly postHandler: TreeNodeMatcherHandler<Ctx, StringTree> | null;
 
   constructor(opts: StrMatcherOptions<Ctx>) {
-    super({ ...opts, type: 'string-tree' });
+    super();
     this.matchers = opts.matchers ?? null;
+    this.preHandler = opts.preHandler ?? null;
     this.postHandler = opts.postHandler ?? null;
+  }
+
+  override match(checkpoint: Checkpoint<Ctx>): Checkpoint<Ctx> | null {
+    const node = checkpoint.cursor.node;
+    if (node.type === 'string-tree') {
+      let context = this.preHandler
+        ? this.preHandler(checkpoint.context, node)
+        : checkpoint.context;
+
+      if (this.matchers) {
+        let cursor = checkpoint.cursor.down;
+        for (const matcher of this.matchers) {
+          if (!cursor) {
+            return null;
+          }
+
+          const match = matcher.match({ context, cursor });
+          if (!match) {
+            return null;
+          }
+
+          context = match.context;
+          cursor = match.endOfLevel ? undefined : match.cursor;
+        }
+
+        if (cursor) {
+          return null;
+        }
+      }
+
+      context = this.postHandler ? this.postHandler(context, node) : context;
+
+      const nextCursor = checkpoint.cursor.right;
+      return nextCursor
+        ? { context, cursor: nextCursor }
+        : { context, cursor: checkpoint.cursor, endOfLevel: true };
+    }
+    return null;
   }
 }

--- a/lib/query/types.ts
+++ b/lib/query/types.ts
@@ -33,16 +33,16 @@ export interface SeqMatcherOptions<Ctx> {
 }
 
 export type TreeNodeMatcherType = TreeType | null;
-export type TreeNodeMatcherHandler<Ctx> = (ctx: Ctx, tree: Tree) => Ctx;
-export interface TreeNodeMatcherOptions<Ctx> {
+export type TreeNodeMatcherHandler<Ctx, T = Tree> = (ctx: Ctx, tree: T) => Ctx;
+export interface TreeNodeMatcherOptions<Ctx, T = Tree> {
   type: TreeNodeMatcherType;
-  preHandler: TreeNodeMatcherHandler<Ctx> | null;
+  preHandler: TreeNodeMatcherHandler<Ctx, T> | null;
 }
 
-export interface TreeNodeWalkingMatcherOptions<Ctx>
-  extends TreeNodeMatcherOptions<Ctx> {
+export interface TreeNodeWalkingMatcherOptions<Ctx, T = Tree>
+  extends TreeNodeMatcherOptions<Ctx, T> {
   matcher: Matcher<Ctx>;
-  postHandler: TreeNodeMatcherHandler<Ctx> | null;
+  postHandler: TreeNodeMatcherHandler<Ctx, T> | null;
 }
 
 export interface Matcher<Ctx> {
@@ -58,11 +58,4 @@ export interface ManyMatcherOptions<Ctx> {
 
 export interface AltMatcherOptions<Ctx> {
   matchers: Matcher<Ctx>[];
-}
-
-export type StrMatcherValue<Ctx> = string | RegExp | Matcher<Ctx>;
-export interface StrMatcherOptions<Ctx> {
-  matchers: StrMatcherValue<Ctx>[] | null;
-  preHandler: TreeNodeMatcherHandler<Ctx> | null;
-  postHandler: TreeNodeMatcherHandler<Ctx> | null;
 }


### PR DESCRIPTION


<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Create string matcher classes with separated responsibility

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/parser-utils/blob/main/.github/PULL_REQUEST_TEMPLATE.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
