### PR TITLE
fix: Correct line joins and unfreeze query result

### DIFF
--- a/lib/lang/index.ts
+++ b/lib/lang/index.ts
@@ -4,6 +4,7 @@ import { createCursor, createTree } from '../parser';
 import type { Cursor } from '../parser/types';
 import { buildRoot } from '../query';
 import { QueryBuilder } from '../query/types';
+import { clone } from '../query/util';
 import { lang as python } from './python';
 import type { LanguageConfig } from './types';
 
@@ -28,7 +29,8 @@ export class Language {
     const matcher = buildRoot(q);
     const cursor = typeof input === 'string' ? this.parse(input) : input;
     const checkpoint = matcher.match({ cursor, context });
-    return checkpoint?.context;
+    const result = checkpoint?.context;
+    return result && clone(result);
   }
 }
 

--- a/lib/lang/python.spec.ts
+++ b/lib/lang/python.spec.ts
@@ -1,4 +1,6 @@
 import { loadInputTxt, loadOutputJson } from '../../test/test-utils';
+import { StringValueToken } from '../lexer/types';
+import * as q from '../query/builder';
 import { lang as pythonLang } from './python';
 import { createLang } from '.';
 
@@ -40,9 +42,9 @@ describe('lang/python', () => {
     expect(res).toMatchObject({
       children: [
         { type: '_start' },
-        { type: 'symbol' },
-        { type: 'whitespace' },
-        { type: 'symbol' },
+        { type: 'symbol', value: 'foo', offset: 0, line: 1, col: 1 },
+        { type: 'whitespace', lineBreaks: 1 },
+        { type: 'symbol', value: 'bar', offset: 5, line: 2, col: 1 },
         { type: '_end' },
       ],
     });

--- a/lib/lang/python.spec.ts
+++ b/lib/lang/python.spec.ts
@@ -1,6 +1,4 @@
 import { loadInputTxt, loadOutputJson } from '../../test/test-utils';
-import { StringValueToken } from '../lexer/types';
-import * as q from '../query/builder';
 import { lang as pythonLang } from './python';
 import { createLang } from '.';
 

--- a/lib/lexer/index.ts
+++ b/lib/lexer/index.ts
@@ -7,18 +7,22 @@ import { fallbackRule } from './rules';
 import { configStrings } from './string';
 import { configSymbols } from './symbol';
 import { coerceToken } from './token';
-import type { Lexer, LexerConfig, StatesMap, Token } from './types';
+import type { Lexer, LexerConfig, RegexRule, StatesMap, Token } from './types';
 
 export * from './token';
 
 export function configureLexerRules(lexerConfig: LexerConfig): StatesMap {
-  const whitespaceMatch = lexerConfig.joinLines
-    ? new RegExp(`(?:${lexerConfig.joinLines}\\r?\\n|[ \\t\\r])+`)
-    : /[ \t\r]+/;
+  const whitespace: RegexRule = lexerConfig.joinLines
+    ? {
+        t: 'regex',
+        match: new RegExp(`(?:${lexerConfig.joinLines}\\r?\\n|[ \\t\\r])+`),
+        lineBreaks: true,
+      }
+    : { t: 'regex', match: /[ \t\r]+/ };
 
   let result: StatesMap = {
     $: {
-      whitespace: { t: 'regex', match: whitespaceMatch },
+      whitespace,
       newline: { t: 'regex', match: /\r?\n/, lineBreaks: true },
       _: fallbackRule,
     },


### PR DESCRIPTION
## Changes:

Correct line/offset counting for lines ending with `\`.
Clone query result.

## Context:

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/parser-utils/blob/main/.github/PULL_REQUEST_TEMPLATE.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
